### PR TITLE
Added data.table to install list.

### DIFF
--- a/bin/INSPIIRED.conda.yml
+++ b/bin/INSPIIRED.conda.yml
@@ -40,6 +40,7 @@ dependencies:
 - r-class=7.3_14=r3.2.2_0a
 - r-cluster=2.0.3=r3.2.2_0a
 - r-codetools=0.2_14=r3.2.2_0a
+- r-data.table=1.9.6=r3.2.2_0a
 - r-foreign=0.8_66=r3.2.2_0a
 - r-getopt=1.20.0=r3.2.2_0
 - r-git2r=0.11.0=r3.2.2_0a


### PR DESCRIPTION
Data.table used in intSiteCaller for loading BLAT output files efficiently.